### PR TITLE
Added SSL-related checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 node_modules

--- a/README.md
+++ b/README.md
@@ -34,11 +34,18 @@ Either way, when you run it, it looks something like this:
 
 ```
 $ bin/link-checker http://localhost:8080/
-[ BROKEN ] URL:      http://localhost:8080/broken-link/
-           Error:    Error: Not Found
-           Referrer: http://localhost:8080/about/
-           Element:  <a href="/broken-link/">Broken Link</a>
-Crawl complete! 1/22 links were broken (4.5% broken)
+[  BROKEN  ] URL:      http://localhost:8080/broken-link/
+             Error:    Error: Not Found
+             Referrer: https://localhost:8080/about/
+             Element:  <a href="/broken-link/">Broken Link</a>
+[ INSECURE ] URL:      http://anotherhost/external.js
+             Error:    Insecure resources cannot be loaded from secured URLs
+             Referrer: https://localhost:8080/about/
+             Element:  <script src="http://anotherhost/external.js"></script>
+
+Crawl complete!
+1/22 links were broken (4.54%)
+1/22 insecure resources loaded from secure URLs (4.54%)
 ```
 
 ### Options
@@ -47,9 +54,12 @@ Crawl complete! 1/22 links were broken (4.5% broken)
 -h, --help               output usage information
 -c, --concurrency <num>  How many links to check concurrently. Default: 5
 -t, --threshold <num>    Exit with error if this many broken links are found. Percentage of broken/total if < 1, count of total broken links if >= 1
+-B, --no-broken          Don’t check for broken links
 -A, --no-assets          Don’t check linked assets like JavaScript and CSS
 -I, --no-images          Don’t check images
 -L, --no-links           Don’t check hyperlinks
+-S, --no-insecure        Don’t check for insecure resource loading
+-m, --minimal            Print minimal messages only showing the type of error, url, and referrer
 -v, --verbose            Be more verbose
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Link Checker
 
-Crawls a page/site and reports broken links or images.
+Crawls a page/site and reports broken links or assets and checks for insecure requests on secured URLs.
 
 ## Installation
 

--- a/bin/link-checker
+++ b/bin/link-checker
@@ -8,12 +8,19 @@ program
 .arguments('<url>')
 .option('-c, --concurrency <num>', 'How many links to check concurrently. Default: 5', parseInt, 5)
 .option('-t, --threshold <num>', 'Exit with error if this many broken links are found. Percentage of broken/total if < 1, count of total broken links if >= 1', parseFloat, 0.05)
+.option('-B, --no-broken', 'Don’t check for broken links')
 .option('-A, --no-assets', 'Don’t check linked assets like JavaScript and CSS')
 .option('-I, --no-images', 'Don’t check images')
 .option('-L, --no-links', 'Don’t check hyperlinks')
 .option('-S, --no-insecure', 'Don’t check for linked resources loaded over HTTP when accessing HTTPS urls')
+.option('-m, --minimal', 'Only display the error type and the URL')
 .option('-v, --verbose', 'Be more verbose')
 .action(function (url, env) {
+  if (!program.broken && !program.insecure) {
+    console.log('Broken link checks and insecure link checks are both disabled. There is nothing to do.');
+    process.exit(0);
+  }
+
   cliHandler(url);
 });
 

--- a/bin/link-checker
+++ b/bin/link-checker
@@ -11,6 +11,7 @@ program
 .option('-A, --no-assets', 'Don’t check linked assets like JavaScript and CSS')
 .option('-I, --no-images', 'Don’t check images')
 .option('-L, --no-links', 'Don’t check hyperlinks')
+.option('-S, --no-insecure', 'Don’t check for linked resources loaded over HTTP when accessing HTTPS urls')
 .option('-v, --verbose', 'Be more verbose')
 .action(function (url, env) {
   cliHandler(url);

--- a/lib/cli-handler.js
+++ b/lib/cli-handler.js
@@ -4,6 +4,23 @@ var program = require('commander');
 var Queue = require('./queue');
 
 module.exports = function (url) {
+  var logResult = function (code, link) {
+    if (program.minimal || link.ok) {
+      console.log('[%s] %s %s', code.trim(), link.url, link.ok ? '' : link.referrer);
+    } else {
+      var whitespace = '';
+
+      for (var i = 0; i < code.length; i++) {
+        whitespace += ' ';
+      }
+
+      console.log('[ %s ] URL:      %s', code, link.url);
+      console.log('  %s   Error:    %s', whitespace, link.error);
+      console.log('  %s   Referrer: %s', whitespace, link.referrer);
+      console.log('  %s   Element:  %s', whitespace, link.html);
+    }
+  };
+
   var Watcher = new EventEmitter();
 
   Watcher.on('done', function (links) {
@@ -20,30 +37,43 @@ module.exports = function (url) {
     });
 
     var insecure = _.sumBy(links, function(link) {
-      return link.insecureReferences;
+      return link.insecureResourceReferences;
     });
 
-    console.log('Crawl complete!');
-    console.log('Broken: %s Broken/Total: %s', broken, (broken/total).toFixed(5));
-    console.log('Insecure: %s Insecure/Total: %s', insecure, (insecure/total).toFixed(5));
+    console.log('\nCrawl complete!');
+
+    if (program.broken) {
+      console.log('Broken   : %s; Percent of total: %s%', broken, (broken / total * 100).toFixed(2));
+    }
+
+    if (program.insecure) {
+      console.log('Insecure : %s; Percent of total: %s%', insecure, (insecure / total * 100).toFixed(2));
+    }
+
+    var invalid_total;
 
     if(program.threshold < 1) {
-      process.exit(((broken/total + insecure/total) < program.threshold) ? 0 : 1);
+      invalid_total = (program.broken ? broken/total : 0) + (program.insecure ? insecure/total : 0);
+      process.exit((invalid_total < program.threshold) ? 0 : 1);
     }
     else {
-      process.exit(((broken + insecure) < program.threshold) ? 0 : 1);
+      invalid_total = (program.broken ? broken : 0) + (program.insecure ? insecure : 0);
+      process.exit((invalid_total < program.threshold) ? 0 : 1);
+    }
+  });
+
+  Watcher.on('insecure-reference', function (link) {
+    if (program.insecure) {
+      logResult('INSECURE', link);
     }
   });
 
   Watcher.on('response', function (link) {
-    if(link.broken) {
-      console.log('[ BROKEN ] URL:      %s', link.url);
-      console.log('           Error:    %s', link.error);
-      console.log('           Referrer: %s', link.referrer);
-      console.log('           Element:  %s', link.html);
+    if(link.broken && program.broken) {
+      logResult(' BROKEN ', link);
     }
     else if(program.verbose) {
-      console.log('[   OK   ] URL:      %s', link.url);
+      logResult('   OK   ', link);
     }
   });
 
@@ -54,6 +84,7 @@ module.exports = function (url) {
   });
 
   Queue.add({
-    url: url
+    url: url,
+    referrer: url // Cheap way to avoid checks on the referrer later
   });
 };

--- a/lib/cli-handler.js
+++ b/lib/cli-handler.js
@@ -19,12 +19,19 @@ module.exports = function (url) {
       return 0;
     });
 
-    console.log('Crawl complete! Broken: %s Broken/Total: %s', broken, (broken/total).toFixed(5));
+    var insecure = _.sumBy(links, function(link) {
+      return link.insecureReferences;
+    });
+
+    console.log('Crawl complete!');
+    console.log('Broken: %s Broken/Total: %s', broken, (broken/total).toFixed(5));
+    console.log('Insecure: %s Insecure/Total: %s', insecure, (insecure/total).toFixed(5));
+
     if(program.threshold < 1) {
-      process.exit((broken/total < program.threshold) ? 0 : 1);
+      process.exit(((broken/total + insecure/total) < program.threshold) ? 0 : 1);
     }
     else {
-      process.exit((broken < program.threshold) ? 0 : 1);
+      process.exit(((broken + insecure) < program.threshold) ? 0 : 1);
     }
   });
 

--- a/lib/cli-handler.js
+++ b/lib/cli-handler.js
@@ -43,11 +43,11 @@ module.exports = function (url) {
     console.log('\nCrawl complete!');
 
     if (program.broken) {
-      console.log('Broken   : %s; Percent of total: %s%', broken, (broken / total * 100).toFixed(2));
+      console.log('%s/%s links were broken (%s%)', broken, total, (broken/total*100).toFixed(2));
     }
 
     if (program.insecure) {
-      console.log('Insecure : %s; Percent of total: %s%', insecure, (insecure / total * 100).toFixed(2));
+      console.log('%s/%s insecure resources loaded from secure URLs (%s%)', insecure, total, (insecure/total*100).toFixed(2));
     }
 
     var invalid_total;

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -81,7 +81,8 @@ module.exports = {
       var foundLink = {
         url: element.href,
         html: element.outerHTML,
-        referrer: link.url
+        referrer: link.url,
+        sourceTag: element.tagName
       };
 
       if(foundLink.url.indexOf('#') !== -1) {
@@ -105,6 +106,7 @@ module.exports = {
    */
   parseImages: function (link, window) {
     var images = window.document.querySelectorAll('img[src]');
+
     Array.prototype.forEach.call(images, function (element) {
       // Sometimes we'll get data: URIs and we can't fetch those.
       if(['http:', 'https:'].indexOf(url.parse(element.src).protocol) === -1) {
@@ -114,7 +116,8 @@ module.exports = {
       Queue.add({
         url: element.src,
         html: element.outerHTML,
-        referrer: link.url
+        referrer: link.url,
+        sourceTag: element.tagName
       });
     });
   },
@@ -137,7 +140,8 @@ module.exports = {
       Queue.add({
         url: url.resolve(link.url, element.href || element.src),
         html: element.outerHTML,
-        referrer: link.url
+        referrer: link.url,
+        sourceTag: element.tagName
       });
     });
   }

--- a/lib/link.js
+++ b/lib/link.js
@@ -49,6 +49,20 @@ var Link = Object.create(Object.prototype, {
       this.__broken = value;
     }
   },
+  insecureReferences: {
+    value: [],
+    writable: true,
+    enumerable: true
+  },
+  addInsecureReference: {
+    value: function (referrer) {
+      this.insecureReferences.push(referrer);
+
+      return this.insecureReferences.length;
+    },
+    writable: false,
+    enumerable: false
+  },
   references: {
     value: 1,
     writable: true,

--- a/lib/link.js
+++ b/lib/link.js
@@ -49,16 +49,14 @@ var Link = Object.create(Object.prototype, {
       this.__broken = value;
     }
   },
-  insecureReferences: {
-    value: [],
+  insecureResourceReferences: {
+    value: 0,
     writable: true,
     enumerable: true
   },
-  addInsecureReference: {
-    value: function (referrer) {
-      this.insecureReferences.push(referrer);
-
-      return this.insecureReferences.length;
+  addInsecureResourceReference: {
+    value: function () {
+      return ++this.insecureResourceReferences;
     },
     writable: false,
     enumerable: false
@@ -70,9 +68,7 @@ var Link = Object.create(Object.prototype, {
   },
   addReference: {
     value: function () {
-      this.references++;
-
-      return this.references;
+      return ++this.references;
     },
     writable: false,
     enumerable: false

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -2,6 +2,7 @@ var EventEmitter = require('events').EventEmitter;
 var url = require('url');
 
 var _ = require('lodash');
+var program = require('commander');
 var superagent = require('superagent');
 var jsdom = require('jsdom');
 
@@ -77,7 +78,14 @@ Queue.on('add', function (link) {
   var existingLink = _.find(this.links, function (item) {
     return item.url === link.url;
   });
+
+  var mustBeSecure = program.insecure && link.referrer.indexOf('https:') === 0 && link.sourceTag != 'a';
+
   if(existingLink) {
+    if (mustBeSecure && existingLink.url.indexOf('https:') !== 0) {
+      existingLink.addInsecureReference(link.referrer);
+    }
+
     // Don't add this link to the queue, but note that it got referenced again.
     return existingLink.addReference();
   }
@@ -100,6 +108,10 @@ Queue.on('add', function (link) {
     }
   });
 
+  if (mustBeSecure && newLink.url.indexOf('https:') !== 0) {
+    newLink.addInsecureReference(link.referrer);
+  }
+
   this.links.push(newLink);
   this.fillFetchQueue();
 });
@@ -119,9 +131,5 @@ Queue.once('done', function () {
 });
 
 Queue.add = function (link) {
-  this.emit('add', {
-    url: link.url,
-    html: link.html,
-    referrer: link.referrer
-  });
+  this.emit('add', _.extend({}, link));
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -2,7 +2,6 @@ var EventEmitter = require('events').EventEmitter;
 var url = require('url');
 
 var _ = require('lodash');
-var program = require('commander');
 var superagent = require('superagent');
 var jsdom = require('jsdom');
 
@@ -75,44 +74,47 @@ Queue.once('init', function (options) {
  * start processing by calling Queue.fillFetchQueue
  */
 Queue.on('add', function (link) {
-  var existingLink = _.find(this.links, function (item) {
+  var subjectLink = _.find(this.links, function (item) {
     return item.url === link.url;
   });
+  var subjectMustBeSecure = link.referrer.indexOf('https:') === 0 && link.sourceTag !== 'A';
 
-  var mustBeSecure = program.insecure && link.referrer.indexOf('https:') === 0 && link.sourceTag != 'a';
+  if (!subjectLink) {
+    subjectLink = Object.create(Link, {
+      url: {
+        value: link.url,
+        enumerable: true,
+        writable: false
+      },
+      html: {
+        value: link.html,
+        enumerable: true,
+        writable: false
+      },
+      referrer: {
+        value: link.referrer,
+        enumerable: true,
+        writable: false
+      }
+    });
+  }
 
-  if(existingLink) {
-    if (mustBeSecure && existingLink.url.indexOf('https:') !== 0) {
-      existingLink.addInsecureReference(link.referrer);
-    }
+  // The referrer was loaded securely but the resource is not
+  if (subjectMustBeSecure && subjectLink.url.indexOf('https:') !== 0) {
+    this.Watcher.emit('insecure-reference', _.extend({}, subjectLink, {
+      error: 'Error: Insecure resources cannot be loaded from secured URLs.',
+      referrer: link.referrer
+    }));
 
+    subjectLink.addInsecureResourceReference();
+  }
+
+  if(subjectLink === link) {
     // Don't add this link to the queue, but note that it got referenced again.
-    return existingLink.addReference();
+    return subjectLink.addReference();
   }
 
-  var newLink = Object.create(Link, {
-    url: {
-      value: link.url,
-      enumerable: true,
-      writable: false
-    },
-    html: {
-      value: link.html,
-      enumerable: true,
-      writable: false
-    },
-    referrer: {
-      value: link.referrer,
-      enumerable: true,
-      writable: false
-    }
-  });
-
-  if (mustBeSecure && newLink.url.indexOf('https:') !== 0) {
-    newLink.addInsecureReference(link.referrer);
-  }
-
-  this.links.push(newLink);
+  this.links.push(subjectLink);
   this.fillFetchQueue();
 });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "recursive-link-checker",
-  "version": "0.2.0",
-  "description": "Crawls a page/site and reports broken links or images.",
+  "version": "0.3.0",
+  "description": "Crawls a page/site and reports broken links or assets and checks for insecure requests on secured URLs.",
   "main": "bin/link-checker",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
I've added some additional functionality to check for external resources (javascript scripts, stylesheets, or images) being loaded over HTTP when the site is SSL-enabled since those requests are blocked by browsers. 

I also added the ability to check for links pointing the user to a plain HTTP link from an SSL-enabled site. This was more so a nice-to-have as it's not really an issue with browsers, but I can see some scenarios in which people would find it useful.